### PR TITLE
cmd+aws: read PORT env and use as port (fixes #29)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-roasterd: ./roasterd
+web: ./roasterd

--- a/cmd/roasterd/main.go
+++ b/cmd/roasterd/main.go
@@ -2,11 +2,17 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/LuleaUniversityOfTechnology/2018-project-roaster/controller"
+)
+
+const (
+	portEnvKey = "PORT"
 )
 
 type flags struct {
@@ -16,7 +22,7 @@ type flags struct {
 }
 
 var context = flags{
-	address:      ":80",
+	address:      ":5000",
 	readTimeout:  15,
 	writeTimeout: 15,
 }
@@ -29,6 +35,10 @@ func init() {
 }
 
 func main() {
+	if port := os.Getenv(portEnvKey); port != "" {
+		context.address = fmt.Sprintf(":%s", port)
+	}
+
 	controller := controller.New()
 
 	server := &http.Server{

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1,9 +1,12 @@
 // Package controller defines all router/mux handles.
 package controller
 
-import "net/http"
-import "github.com/gorilla/mux"
-import "github.com/LuleaUniversityOfTechnology/2018-project-roaster/controller/static"
+import (
+	"net/http"
+
+	"github.com/LuleaUniversityOfTechnology/2018-project-roaster/controller/static"
+	"github.com/gorilla/mux"
+)
 
 // New returns a router with all handles configured.
 func New() *mux.Router {


### PR DESCRIPTION
AWS EBS uses port 5000 as default. It'll define the PORT=5000, which can be read and used too. The Procfile also requires the process to have the `web:` key.