### PR TITLE
www/src: fix nginx eating Roast analyze errors

### DIFF
--- a/www/src/index.ts
+++ b/www/src/index.ts
@@ -35,8 +35,8 @@ class Roaster {
 
         return;
       }
-    } catch (e) {
-      console.log('Unhandled response: ' + e);
+    } catch (error) {
+      console.log('Unhandled response: ' + error);
     }
 
     UserModel.setLoggedIn(false);

--- a/www/src/services/network.ts
+++ b/www/src/services/network.ts
@@ -3,6 +3,26 @@ import ξ from 'mithril';
 const xCsrfToken: string = 'X-Csrf-Token';
 const contentType: string = 'Content-Type';
 
+// APIError is used as an helper to create a Error with a code property.
+//
+// This class should _not_ be used outside of this service. TypeScript has no
+// standard way of narrowing errors with the `cause` clause, i.e. no type-safety
+// inside the `cause` clause.
+//
+// Solution: Just check if the `code` property exists using standard JavaScript,
+// like:
+//    if ('code' in error && error.code == 404) {
+//      doSomething(error.code);
+//    }
+class APIError extends Error {
+  code: number
+
+  constructor(message: string, code?: number) {
+    super(message);
+    this.code = code || 0;
+  }
+};
+
 export default class Network {
   private static nextCSRFToken: string = '';
 
@@ -15,12 +35,20 @@ export default class Network {
 
     Network.nextCSRFToken = token;
 
+    let response: any;
     if (xhr.responseText.length > 0
       && xhr.getResponseHeader(contentType).includes('application/json')) {
-      return JSON.parse(xhr.responseText);
+      response = JSON.parse(xhr.responseText);
+    } else {
+      response = xhr.responseText; // Unparsable data, use raw data instead.
     }
 
-    return xhr.responseText; // Return unparsed data.
+
+    if (xhr.status < 300 || xhr.status == 304) {
+      return response;
+    }
+
+    throw new APIError(response.message || response, xhr.status);
   };
 
   private static async initCSRFToken() {


### PR DESCRIPTION
Because AWS has a limit, they'll send their HTML formatted error instead of ours. So I've cleaned up the error handling, tried to parse it, and then finally just resort to a frontend side max code snippet length.