### PR TITLE
www/src/services/network: do not set CSRF token if not provided by server

### DIFF
--- a/www/src/services/network.ts
+++ b/www/src/services/network.ts
@@ -26,7 +26,7 @@ class APIError extends Error {
 export default class Network {
   private static nextCSRFToken: string = '';
 
-  private static extractCSRFToken(xhr, xhrOptions): string {
+  private static extract(xhr, xhrOptions): string {
     const token: string = xhr.getResponseHeader(xCsrfToken);
 
     if (token) {
@@ -53,7 +53,7 @@ export default class Network {
     return ξ.request({
       method: 'HEAD',
       url: '/',
-      extract: Network.extractCSRFToken,
+      extract: Network.extract,
     });
   };
 
@@ -70,7 +70,7 @@ export default class Network {
       url: url,
       data: data,
       headers: {[xCsrfToken]: Network.nextCSRFToken},
-      extract: Network.extractCSRFToken,
+      extract: Network.extract,
     });
   };
 }

--- a/www/src/services/network.ts
+++ b/www/src/services/network.ts
@@ -29,11 +29,9 @@ export default class Network {
   private static extractCSRFToken(xhr, xhrOptions): string {
     const token: string = xhr.getResponseHeader(xCsrfToken);
 
-    if (token == '') {
-      throw new Error('empty CSRF token received');
+    if (token) {
+      Network.nextCSRFToken = token;
     }
-
-    Network.nextCSRFToken = token;
 
     let response: any;
     if (xhr.responseText.length > 0


### PR DESCRIPTION
CSRF isn't provided on HTTP errors and for GET, DELETE etc. Just ignore setting the token if it doesn't exist.